### PR TITLE
fixed menu highlight issue for unnamed routes 

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -63,6 +63,7 @@ const routes: RouteRecordRaw[] = [
       },
       {
         path: 'student',
+        name: 'student',
         component: () => import('pages/students/StudentsPage.vue'),
         meta: {
           menu: 'Student',


### PR DESCRIPTION
Two unnamed routes will be highlighted at once on the side-menu/MenuOptions.vue